### PR TITLE
reduce the side effects of the disable function

### DIFF
--- a/shecan.py
+++ b/shecan.py
@@ -23,8 +23,7 @@ def check_root():
 
 def disable():
     check_root()
-    os.system("cat /etc/resolv.conf.tmp > /etc/resolv.conf")
-    os.system("rm /etc/resolv.conf.tmp")
+    os.system("mv /etc/resolv.conf.tmp /etc/resolv.conf")
     print("shcan disabled")
 
 def enable():


### PR DESCRIPTION
**issue:** If you accidentally disable Shecan before enabling it, the content of the `/etc/resolv.conf` file will erase.

This commit resolves the mentioned issue.